### PR TITLE
First automation step for generation of catalogs from JSON metadata and Jinja2 templates 

### DIFF
--- a/docs/_templates/catalog.rst
+++ b/docs/_templates/catalog.rst
@@ -1,19 +1,19 @@
-{% set title = pyscf.get("name") %}
-.. _ pyscf:
+{% set title = NAME.get("name") %}
+.. _ NAME:
 
 *************
 {{title}}
 *************
 
 {% block content %}
-    {{ pyscf.description }}
+    {{ NAME.description }}
 {% endblock content %}
 
 Source Specifications
 =====================
 
 {% block specifications %}
-    {% for dc in pyscf.source_specifications %}
+    {% for dc in NAME.source_specifications %}
         {% for key, value in dc.items() %}
             * **{{ key }}**: {{ value }}
         {% endfor %}
@@ -24,7 +24,7 @@ MolSSI-AI Container Hub Specifications
 ======================================
 
 {% block hub_specifications %}
-    {% for dc in pyscf.hub_specifications %}
+    {% for dc in NAME.hub_specifications %}
         {% for key, value in dc.items() %}
             * **{{ key }}**: {{ value }}
         {% endfor %}
@@ -35,19 +35,19 @@ MolSSI-AI Container Hub Specifications
 
     .. code-block:: bash
 
-        {{ pyscf.docker_pull_command }}
+        {{ NAME.docker_pull_command }}
 
 * **Container run command**:
 
     .. code-block:: bash
 
-        {{ pyscf.docker_run_command }}
+        {{ NAME.docker_run_command }}
 
 {% block note %}
-{% if pyscf.gpu_note != "" %}
+{% if NAME.gpu_note != "" %}
 .. note::
 
-        {{ pyscf.gpu_note }}
+        {{ NAME.gpu_note }}
 {% endif %}
 {% endblock note %}
 
@@ -55,7 +55,7 @@ Image Specifications
 ====================
 
 {% block image_specifications %}
-    {% for dc in pyscf.image_specifications %}
+    {% for dc in NAME.image_specifications %}
         {% for key, value in dc.items() %}
             {% if key != "Extras" %}
                 * **{{ key }}**: {{ value }}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -178,11 +178,10 @@ for directory in json_file_path:
     with open("./_templates/catalog.rst", "r") as t:
         target_dir = Path(".")
         for target in mydir.parts[:-1]:
-            target_dir.joinpath(target)
+            target_dir = target_dir.joinpath(target)
         if not target_dir.exists():
             Path.mkdir(target_dir)
-        my_rst_file = str(target_dir).join(name + ".rst")
-        print(my_rst_file)
+        my_rst_file = str(target_dir) + "/" + name + ".rst"
         with open(my_rst_file,"w") as g:
             g.write(t.read().replace("NAME", name))
     with open(str(directory.resolve()), "r", encoding='utf-8') as f:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -163,7 +163,32 @@ html_show_copyright = False
 # 'searchbox.html']``.
 #
 # html_sidebars = {}
+from pathlib import Path
+import json
 
+json_file_path = sorted(Path("../molssiai_hub").glob("**/*.json"))
+html_context = {}
+
+for directory in json_file_path:
+    dir_parts = directory.parts[2:-1]
+    name = dir_parts[-1]
+    mydir = Path(".")
+    for itm in dir_parts: 
+        mydir = mydir.joinpath(itm)
+    with open("./_templates/catalog.rst", "r") as t:
+        target_dir = Path(".")
+        for target in mydir.parts[:-1]:
+            target_dir.joinpath(target)
+        if not target_dir.exists():
+            Path.mkdir(target_dir)
+        my_rst_file = str(target_dir).join(name + ".rst")
+        print(my_rst_file)
+        with open(my_rst_file,"w") as g:
+            g.write(t.read().replace("NAME", name))
+    with open(str(directory.resolve()), "r", encoding='utf-8') as f:
+        idx = json.load(f)
+        html_context[name] = idx
+  
 def rstjinja(app, docname, source):
     """
     Render our pages as a jinja template for fancy templating goodness.
@@ -180,21 +205,6 @@ def rstjinja(app, docname, source):
 def setup(app):
     app.connect("source-read", rstjinja)
 
-json_file_path = []
-for path, subdirs, files in os.walk("../molssiai_hub"):
-    for name in files:
-        if name.endswith(".json"):
-            json_file_path.append(os.path.join(path, name))
-
-import json
-
-html_context = {}
-for jfile in json_file_path:
-    with open(jfile, "r", encoding='utf-8') as f:
-        idx = json.load(f)
-        html_context[idx["name"]] = idx
-
-print(html_context.keys())
 # -- Options for HTMLHelp output ---------------------------------------------
 
 # Output file base name for HTML help builder.

--- a/docs/machine_learning/torchani.rst
+++ b/docs/machine_learning/torchani.rst
@@ -1,19 +1,19 @@
-{% set page_name = TorchANI.get("name") %}
-.. _{{ page_name }}:
+{% set title = torchani.get("name") %}
+.. _ torchani:
 
 *************
-{{page_name}}
+{{title}}
 *************
 
 {% block content %}
-    {{ TorchANI.description }}
+    {{ torchani.description }}
 {% endblock content %}
 
 Source Specifications
 =====================
 
 {% block specifications %}
-    {% for dc in TorchANI.source_specifications %}
+    {% for dc in torchani.source_specifications %}
         {% for key, value in dc.items() %}
             * **{{ key }}**: {{ value }}
         {% endfor %}
@@ -24,7 +24,7 @@ MolSSI-AI Container Hub Specifications
 ======================================
 
 {% block hub_specifications %}
-    {% for dc in TorchANI.hub_specifications %}
+    {% for dc in torchani.hub_specifications %}
         {% for key, value in dc.items() %}
             * **{{ key }}**: {{ value }}
         {% endfor %}
@@ -35,23 +35,27 @@ MolSSI-AI Container Hub Specifications
 
     .. code-block:: bash
 
-        {{ TorchANI.docker_pull_command }}
+        {{ torchani.docker_pull_command }}
 
 * **Container run command**:
 
     .. code-block:: bash
 
-        {{ TorchANI.docker_run_command }}
+        {{ torchani.docker_run_command }}
 
+{% block note %}
+{% if torchani.gpu_note != "" %}
 .. note::
 
-        {{ TorchANI.gpu_note }}
+        {{ torchani.gpu_note }}
+{% endif %}
+{% endblock note %}
 
 Image Specifications
 ====================
 
 {% block image_specifications %}
-    {% for dc in TorchANI.image_specifications %}
+    {% for dc in torchani.image_specifications %}
         {% for key, value in dc.items() %}
             {% if key != "Extras" %}
                 * **{{ key }}**: {{ value }}

--- a/molssiai_hub/compchem/pyscf/metadata.json
+++ b/molssiai_hub/compchem/pyscf/metadata.json
@@ -1,0 +1,37 @@
+{
+    "name": "PySCF",
+    "description": "The Python-based Simulations of Chemistry Framework (PySCF) is an open-source collection of electronic structure modules written in Python.",
+    "source_specifications": [
+        {
+            "Developers": "`PySCF Developers Team <https://pyscf.org/about.html>`_",
+            "Github": "https://github.com/pyscf/pyscf",
+            "Documentation": "https://pyscf.org/user.html"
+        }
+    ],
+    "hub_specifications": [
+        {
+            "Repository": "https://hub.docker.com/r/molssiai/pyscf221-base-mamba141-jupyter",
+            "Tags": "https://hub.docker.com/r/molssiai/pyscf221-base-mamba141-jupyter/tags",
+            "Github":"",
+            "Dockerfile":""
+        }
+    ],
+    "docker_pull_command": "docker pull molssiai/pyscf221-base-mamba141-jupyter:5.15.2023",
+    "docker_run_command": "docker run -it --name torchani molssiai/pyscf221-base-mamba141-jupyter:5.15.2023 /bin/bash",
+    "gpu_note": "",
+    "image_specifications":[
+        {
+            "OS/Arch": "debian:bullseye-slim (linux/amd64)",
+            "User(s)": "root",
+            "Environment variables": "None",
+            "Volumes": "None",
+            "Network": "None",
+            "Extras": [
+                {
+                    "Added directories": "None",
+                    "Important packages installed": "None"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
# Summary

This PR tries to put in place an infrastructure that allows a full automation of catalog generation based on Jinja2 templates (e.g., see **_templates/catalog.rst**) and **metadata.json** in each software's folder.