### PR TITLE
fixes the GitHub icon link in the documentation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -133,7 +133,7 @@ html_theme = 'pydata_sphinx_theme'
 #     'titles_only': False
 # }
 html_theme_options = {
-    "github_url": "https://github.com/molssi-ai/molssiai_hub",
+    "github_url": "https://github.com/molssi-ai/molssi-ai-hub",
     "twitter_url": "https://twitter.com/MolSSI_NSF",
     "logo": {
     "image_light": "_static/molssi_ai.svg",


### PR DESCRIPTION
# Summary

This PR fixes the link behind the GitHub icon that directs the user to the main GitHub repository.