### PR TITLE
Adds the Pytorch Image and Apptainer usage for Psi4

### DIFF
--- a/docs/compchem/psi4_example.rst
+++ b/docs/compchem/psi4_example.rst
@@ -51,7 +51,23 @@ paste it into your terminal and edit it to look like the following command line
 
     docker run --rm -v $(pwd):/home molssiai/psi4v18-mamba141-py310:5.23.2023 /bin/bash -c "psi4 /home/test.inp /home/test.out"
 
-then press Enter. If nothing goes wrong, you should see the following lines in your terminal
+then press Enter. 
+
+.. note::
+
+    The same Docker image recipe can also be used with Apptainer (Singularity) to
+    obrain the same result via the following command
+
+    .. code-block:: bash
+
+        apptainer exec docker://molssiai/psi4v18-mamba141-py310:5.23.2023 psi4 test.inp test.out
+    
+    The aforementioned command should work because Apptainer binds ``/home/$USER``, ``/tmp``
+    and current working directory (``$PWD``) from the host system to the running container 
+    by default. For further details see the Apptainer 
+    `documentation <https://apptainer.org/docs/user/latest/quick_start.html#working-with-files>`_.
+
+If nothing goes wrong, you should see the following lines in your terminal
 
 .. code-block:: bash
 

--- a/docs/machine_learning/index.rst
+++ b/docs/machine_learning/index.rst
@@ -11,6 +11,6 @@ covenient and reproducible way.
 .. toctree::
     :maxdepth: 2
     :titlesonly:
-       
+
+    pytorch201-cu117-mamba141   
     torchani223-cu117-ase-mamba141-jupyter
-    torchani_dev

--- a/docs/machine_learning/pytorch201-cu117-mamba141.rst
+++ b/docs/machine_learning/pytorch201-cu117-mamba141.rst
@@ -1,0 +1,76 @@
+.. _pytorch201_cu117_mamba141:
+
+*********************************************************
+{{ pytorch201_cu117_mamba141.hub_specifications[0]["Github"].split("/")[-1] }}
+*********************************************************
+
+{% set title = pytorch201_cu117_mamba141.get("name") %}
+
+{{title}}
+=========================================================
+
+{% block content %}
+    {{ pytorch201_cu117_mamba141.description }}
+{% endblock content %}
+
+Source Specifications
+=====================
+
+{% block specifications %}
+    {% for dc in pytorch201_cu117_mamba141.source_specifications %}
+        {% for key, value in dc.items() %}
+            * **{{ key }}**: {{ value }}
+        {% endfor %}
+    {% endfor %}
+{% endblock specifications %}
+
+MolSSI-AI Container Hub Specifications
+======================================
+
+{% block hub_specifications %}
+    {% for dc in pytorch201_cu117_mamba141.hub_specifications %}
+        {% for key, value in dc.items() %}
+            * **{{ key }}**: {{ value }}
+        {% endfor %}
+    {% endfor %}
+{% endblock hub_specifications %}
+
+* **Image pull command**:
+
+    .. code-block:: bash
+
+        {{ pytorch201_cu117_mamba141.docker_pull_command }}
+
+* **Container run command**:
+
+    .. code-block:: bash
+
+        {{ pytorch201_cu117_mamba141.docker_run_command }}
+
+{% block note %}
+{% if pytorch201_cu117_mamba141.note != "" %}
+.. note::
+
+        {{ pytorch201_cu117_mamba141.note }}
+{% endif %}
+{% endblock note %}
+
+Image Specifications
+====================
+
+{% block image_specifications %}
+    {% for dc in pytorch201_cu117_mamba141.image_specifications %}
+        {% for key, value in dc.items() %}
+            {% if dc[key] is string or dc[key] == "" %}
+                * **{{ key }}**: {{ value }}
+            {% else %}
+                * **{{ key }}**:
+                {% for key2 in dc[key] %}
+                    {% for key3, val3 in key2.items() %}
+                        + *{{ key3 }}*: {{ val3 }}
+                    {% endfor %}
+                {% endfor %}
+            {% endif %}
+        {% endfor %}
+    {% endfor %}
+{% endblock image_specifications %}

--- a/docs/machine_learning/torchani_dev.rst
+++ b/docs/machine_learning/torchani_dev.rst
@@ -1,7 +1,0 @@
-.. _torchani_dev:
-
-************
-TorchANI-dev
-************
-
-This is the page for torchani-dev

--- a/molssiai_hub/machine_learning/pytorch201-cu117-mamba141/Dockerfile
+++ b/molssiai_hub/machine_learning/pytorch201-cu117-mamba141/Dockerfile
@@ -1,0 +1,12 @@
+FROM molssiai/mamba141:5.2.2023
+
+LABEL maintainer="Mohammad Mostafanejad, \
+                  MolSSI-AI, Molecular Sciences Software Institute"
+
+RUN mamba install pytorch \
+    torchvision \
+    torchaudio \
+    pytorch-cuda=11.7 \
+    -c pytorch \
+    -c nvidia -yq \
+ && mamba clean -ay

--- a/molssiai_hub/machine_learning/pytorch201-cu117-mamba141/metadata.json
+++ b/molssiai_hub/machine_learning/pytorch201-cu117-mamba141/metadata.json
@@ -1,0 +1,41 @@
+{
+    "name": "PyTorch",
+    "description": "PyTorch is an optimized tensor library for deep learning using GPUs and CPUs.",
+    "source_specifications": [
+        {
+            "Developers": "`PyTorch Maintainers <https://pytorch.org/docs/master/community/persons_of_interest.html>`_",
+            "Github": "https://github.com/pytorch/pytorch",
+            "Documentation": "https://pytorch.org/docs/stable/index.html"
+        }
+    ],
+    "hub_specifications": [
+        {
+            "Repository": "https://hub.docker.com/r/molssiai/pytorch201-cu117-mamba141",
+            "Tags": "https://hub.docker.com/r/molssiai/pytorch201-cu117-mamba141/tags",
+            "Github":"https://github.com/molssi-ai/molssi-ai-hub/tree/main/molssiai_hub/machine_learning/pytorch201-cu117-mamba141",
+            "Dockerfile":"https://github.com/molssi-ai/molssi-ai-hub/blob/main/molssiai_hub/machine_learning/pytorch201-cu117-mamba141/Dockerfile"
+        }
+    ],
+    "docker_pull_command": "docker pull molssiai/pytorch201-cu117-mamba141:latest",
+    "docker_run_command": "docker run -it --name pytorch -v $(pwd):/home molssiai/pytorch201-cu117-mamba141:latest /bin/bash",
+    "note": "By default, the ``-v $(pwd):/home`` option mounts the current working directory to ``/home`` in your running container. Doing so, the contents of your current working directory become available in your running container. If you do not wish this to happen, you may simply remove or change this option. For NVIDIA GPU support with nvidia containers, add the ``--runtime nvidia --gpus all`` flags to the previous container run command and then run ``nvidia-smi`` to make sure all available GPUs on the docker host are visible inside the docker container.",
+    "image_specifications":[
+        {
+            "OS/Arch": "debian:bullseye-slim (linux/amd64)",
+            "User(s)": "root",
+            "Environment variables":  [
+                {
+                    "PATH":"/opt/conda/bin"
+                }
+            ],
+            "Volumes": "$(pwd):/home",
+            "Network": "None",
+            "Extras": [
+                {
+                    "Added directories": "None",
+                    "Important packages installed": "pytorch-cuda 11.7, torchaudio, torchvision"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
# Summary

The present PR adds the following changes:
* A new Dockerfile image recipe for PyTorch 2.0.1 + CUDA 11.7 (GPU support) with mamba 1.4.1
* A note describing usage of PSI4 image with Apptainer is added to the example page