### PR TITLE
correction to commands for running postgres container

### DIFF
--- a/molssi_hub/compchem/rdkit-postgres162/metadata.json
+++ b/molssi_hub/compchem/rdkit-postgres162/metadata.json
@@ -16,8 +16,8 @@
             "Recipe":"https://github.com/MolSSI/molssi-hub/blob/main/molssi_hub/compchem/rdkit-postgres162/Dockerfile"
         }
     ],
-    "docker_pull_command": "docker pull molssi/rdkitpostgres-postgres162:latest",
-    "docker_run_command": "docker run --name rdkitpostgres -e POSTGRES_PASSWORD=mysecretpassword -p 5432:5432 -d molssi/rdkitpostgres-postgres162:latest",
+    "docker_pull_command": "docker pull molssi/rdkit-postgres162:latest",
+    "docker_run_command": "docker run --name rdkitpostgres -e POSTGRES_PASSWORD=mysecretpassword -p 5432:5432 -d molssi/rdkit-postgres162:latest",
     "note": "See the full documentation for the base PostgreSQL image for alternative environment variables and run commands - https://hub.docker.com/_/postgres",
     "tip": "See the full documentation for the base PostgreSQL image for alternative environment variables and run commands - https://hub.docker.com/_/postgres",
     "image_specifications":[


### PR DESCRIPTION
This PR edits the commands for pulling and running the RDKit postgres container so that it matches what is on the MolSSI Container DockerHub.